### PR TITLE
Add id to the 'Open sidebar' option

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -76,6 +76,7 @@
 			</NcActionButton>
 			<!-- Menu items -->
 			<NcActionButton v-if="Sidebar && sidebarOpenFilePath && !isSidebarShown"
+				id="viewer-sidebar-btn"
 				:close-after-click="true"
 				icon="icon-menu-sidebar"
 				@click="showSidebar">


### PR DESCRIPTION
'Open sidebar' option in the popover will now have id so that we can access it through css